### PR TITLE
Par-for optimization

### DIFF
--- a/best/mem/be_launch_mem.m
+++ b/best/mem/be_launch_mem.m
@@ -92,7 +92,7 @@ if OPTIONS.solver.parallel_matlab == 1
     time_it_starts = tic;
     parfor ii = 1 : nbSmp
         
-        [R, E, A, S] = MEM_mainLoop(ii,OPTIONS_litle, obj_slice(ii),obj_const);
+        [R, E, A, S] = MEM_mainLoop(ii, obj_slice(ii),obj_const,OPTIONS_litle);
 
         entropy_drop(ii)        =  E;
         final_alpha{ii}         =  A;
@@ -117,7 +117,7 @@ else
     time_it_starts = tic;
     for ii = 1 : nbSmp
 
-        [R, E, A, S] = MEM_mainLoop(ii,OPTIONS_litle, obj_slice(ii),obj_const);
+        [R, E, A, S] = MEM_mainLoop(ii,obj_slice(ii),obj_const,OPTIONS_litle);
 
         entropy_drop(ii)	    = E;        
         final_alpha{ii}  	    = A;
@@ -179,10 +179,9 @@ end
 
 % =========================================================================
 
-function [R, E, A, S] = MEM_mainLoop(ii,OPTIONS, obj, obj_const)
-    obj.GreenM2  = obj_const.GreenM2;
-    obj.gain     = obj_const.gain;
-
+function [R, E, A, S] = MEM_mainLoop(ii, obj, obj_const, OPTIONS)
+    obj = be_struct_copy_fields(obj, obj_const, []);
+    
     if ~sum(obj.clusters)
         if OPTIONS.optional.verbose
             disp(['MEM warning: The distributed dipoles could not be clusterized at sample ' num2str(ii) '. (null solution returned)']);

--- a/best/mem/be_launch_mem.m
+++ b/best/mem/be_launch_mem.m
@@ -92,7 +92,7 @@ if OPTIONS.solver.parallel_matlab == 1
     time_it_starts = tic;
     parfor ii = 1 : nbSmp
         
-        [R, E, A, S] = MEM_mainLoop(ii, obj_slice(ii),obj_const,OPTIONS_litle);
+        [R, E, A, S] = MEM_mainLoop(ii, obj_slice(ii), obj_const, OPTIONS_litle);
 
         entropy_drop(ii)        =  E;
         final_alpha{ii}         =  A;
@@ -117,7 +117,7 @@ else
     time_it_starts = tic;
     for ii = 1 : nbSmp
 
-        [R, E, A, S] = MEM_mainLoop(ii,obj_slice(ii),obj_const,OPTIONS_litle);
+        [R, E, A, S] = MEM_mainLoop(ii, obj_slice(ii), obj_const, OPTIONS_litle);
 
         entropy_drop(ii)	    = E;        
         final_alpha{ii}  	    = A;

--- a/best/mem/be_launch_mem.m
+++ b/best/mem/be_launch_mem.m
@@ -75,15 +75,12 @@ end
 if ~OPTIONS.automatic.stand_alone
     bst_progress('start', 'Solving MEM', 'Solving MEM', 0, nbSmp);
 end
+
 isVerbose       = OPTIONS.optional.verbose;
 isStandAlone    = OPTIONS.automatic.stand_alone;
 
-[obj_slice, obj_const] = be_slice_obj(obj, OPTIONS);
-OPTIONS2 = OPTIONS;
-OPTIONS2.automatic   = rmfield(OPTIONS2.automatic,'Modality');
-OPTIONS2             = rmfield(OPTIONS2,'mandatory');
-OPTIONS2.optional.TimeSegment = [];
-OPTIONS2.optional.Baseline = [];
+[OPTIONS_litle, obj_slice, obj_const] = be_slice_obj(Data, obj, OPTIONS);
+
 
 if OPTIONS.solver.parallel_matlab == 1    
     
@@ -94,16 +91,13 @@ if OPTIONS.solver.parallel_matlab == 1
 
     time_it_starts = tic;
     parfor ii = 1 : nbSmp
-       [R, E, A, S] = MEM_mainLoop(ii,OPTIONS2, obj_slice(ii),obj_const);
-
-
-
-        entropy_drop(ii)    =   E;
-        final_alpha{ii}     =   A;
-        final_sigma{ii}     =   S;
         
-        %Store in a matrix
-        ImageSourceAmp(:, ii)      =  R;
+        [R, E, A, S] = MEM_mainLoop(ii,OPTIONS_litle, obj_slice(ii),obj_const);
+
+        entropy_drop(ii)        =  E;
+        final_alpha{ii}         =  A;
+        final_sigma{ii}         =  S;
+        ImageSourceAmp(:, ii)   =  R;
         if ~isStandAlone
             send(q, 1); 
         end
@@ -123,14 +117,13 @@ else
     time_it_starts = tic;
     for ii = 1 : nbSmp
 
-       [R, E, A, S] = MEM_mainLoop(ii,OPTIONS2, obj_slice(ii),obj_const);
+        [R, E, A, S] = MEM_mainLoop(ii,OPTIONS_litle, obj_slice(ii),obj_const);
 
-        entropy_drop(ii)	= E;        
-        final_alpha{ii}  	= A;
-        final_sigma{ii}     = S;
-        
-        % Store in matrix
-        ImageSourceAmp(:, ii)      =  R;
+        entropy_drop(ii)	    = E;        
+        final_alpha{ii}  	    = A;
+        final_sigma{ii}         = S;
+        ImageSourceAmp(:, ii)   = R;
+
         if ~isStandAlone
             bst_progress('inc', 1);
         end
@@ -212,7 +205,7 @@ function [R, E, A, S] = MEM_mainLoop(ii,OPTIONS, obj, obj_const)
         entropy_drop= mem_results_struct.entropy;
         act_proba   = mem_results_struct.active_probability;    
 
-        if OPTIONS.optional.verbose, fprintf('Sample %3d(%2d,%3.3f):',ii,obj.scale,obj.time); end;           
+        if OPTIONS.optional.verbose, fprintf('Sample %3d(%2d,%3.3f):',ii,obj.scale,obj.time); end
         
         % Print output
         if sum(isnan(J))

--- a/best/mem/be_slice_obj.m
+++ b/best/mem/be_slice_obj.m
@@ -1,0 +1,72 @@
+function [obj_slice, obj_const] = be_slice_obj(obj, OPTIONS)
+    nbSmp = size(obj.ALPHA,2); 
+    obj_slice(nbSmp) = struct();
+
+    Data = [];
+
+    if ~isempty(OPTIONS.automatic.selected_samples)        
+        Data = [Data;obj.data{1}(:,OPTIONS.automatic.selected_samples(1,:))];                 
+    elseif ~strcmp(OPTIONS.mandatory.pipeline,'wMEM')
+        Data  = obj.data;
+    end
+
+    for i = 1:nbSmp
+
+        obj_slice(i).SCR = obj.SCR(:,i);
+        obj_slice(i).CLS = obj.CLS(:,i);
+        obj_slice(i).ALPHA = obj.ALPHA(:,i);
+
+        obj_slice(i).clusters           = obj.CLS(:,i);
+        obj_slice(i).active_probability = obj.ALPHA(:,i);
+
+        obj_slice(i).data   = Data(:,i);
+        obj_slice(i).time   = obj.time(:,i);
+        obj_slice(i).scale  = obj.scale(:,i);
+
+        obj_slice(i).Jmne   = OPTIONS.automatic.Modality(1).Jmne(:,i) ;
+        obj_slice(i).Jmne   = obj_slice(i).Jmne ./ max(abs(obj_slice(i).Jmne));
+
+        % check if there's a noise cov for each scale
+        if (size(obj.noise_var,3) > 1) && OPTIONS.optional.baseline_shuffle ~= 1
+            if OPTIONS.optional.verbose
+                fprintf('%s, Noise variance at scale %i is selected\n',...
+                    OPTIONS.mandatory.pipeline,OPTIONS.automatic.selected_samples(2,ii));
+            end
+            obj_slice(i).noise_var = squeeze(obj.noise_var(:,:,OPTIONS.automatic.selected_samples(2,ii)) );
+        
+        elseif (size(obj.noise_var,3)>1) && OPTIONS.optional.baseline_shuffle == 1
+    
+            tol = OPTIONS.optional.baseline_shuffle_windows / 2; 
+            idx_baseline = find(obj.time(i) > OPTIONS.automatic.Modality(1).BaselineTime(1,:) & ...
+                                obj.time(i) <=  (OPTIONS.automatic.Modality(1).BaselineTime(end,:)+tol));
+        
+            if isempty(idx_baseline) && obj.time(i) > max(max(OPTIONS.automatic.Modality(1).BaselineTime))
+                idx_baseline = size(OPTIONS.automatic.Modality(1).BaselineTime,2);
+            elseif isempty(idx_baseline) && obj.time(i) < min(min(OPTIONS.automatic.Modality(1).BaselineTime))
+                idx_baseline = 1;
+            elseif length(idx_baseline) > 1
+                idx_baseline = idx_baseline(2);
+            end
+    
+            if OPTIONS.optional.verbose
+                fprintf('%s, Noise variance from baseline %i is selected\n',...
+                    OPTIONS.mandatory.pipeline, idx_baseline);
+            end
+            obj_slice(i).noise_var = squeeze(obj.noise_var(:,:, idx_baseline) );
+        else
+
+            obj_slice(i).noise_var = obj.noise_var;
+        end
+
+
+        obj_slice(i).nb_sources  = obj.nb_sources;
+        obj_slice(i).nb_channels = obj.nb_channels;
+        obj_slice(i).nb_dipoles  = obj.nb_dipoles;
+
+    end
+
+    obj_const.GreenM2  = obj.GreenM2;
+    obj_const.gain     = obj.gain;
+     
+end
+

--- a/best/mem/be_slice_obj.m
+++ b/best/mem/be_slice_obj.m
@@ -1,14 +1,7 @@
-function [obj_slice, obj_const] = be_slice_obj(obj, OPTIONS)
-    nbSmp = size(obj.ALPHA,2); 
+function [OPTIONS, obj_slice, obj_const] = be_slice_obj(Data,obj, OPTIONS)
+
+    nbSmp = size(Data,2); 
     obj_slice(nbSmp) = struct();
-
-    Data = [];
-
-    if ~isempty(OPTIONS.automatic.selected_samples)        
-        Data = [Data;obj.data{1}(:,OPTIONS.automatic.selected_samples(1,:))];                 
-    elseif ~strcmp(OPTIONS.mandatory.pipeline,'wMEM')
-        Data  = obj.data;
-    end
 
     for i = 1:nbSmp
 
@@ -67,6 +60,12 @@ function [obj_slice, obj_const] = be_slice_obj(obj, OPTIONS)
 
     obj_const.GreenM2  = obj.GreenM2;
     obj_const.gain     = obj.gain;
-     
+
+
+    OPTIONS.automatic   = rmfield(OPTIONS.automatic,'Modality');
+    OPTIONS             = rmfield(OPTIONS,'mandatory');
+    OPTIONS.optional.TimeSegment = [];
+    OPTIONS.optional.Baseline = [];
+
 end
 

--- a/best/mem/be_slice_obj.m
+++ b/best/mem/be_slice_obj.m
@@ -48,7 +48,7 @@ function [OPTIONS, obj_slice, obj_const] = be_slice_obj(Data,obj, OPTIONS)
             obj_slice(i).noise_var = squeeze(obj.noise_var(:,:, idx_baseline) );
         else
 
-            obj_slice(i).noise_var = obj.noise_var;
+            obj_const.noise_var = obj.noise_var;
         end
 
 

--- a/best/misc/mne/be_jmne_lcurve.m
+++ b/best/misc/mne/be_jmne_lcurve.m
@@ -76,8 +76,9 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
 
     Fit     = zeros(1,length(alpha));
     Prior   = zeros(1,length(alpha));
-
-    bst_progress('start', 'wMNE, solving MNE by L-curve ... ' , 'Solving MNE by L-curve ... ', 1, length(param1));
+    if ~OPTIONS.automatic.stand_alone
+        bst_progress('start', 'wMNE, solving MNE by L-curve ... ' , 'Solving MNE by L-curve ... ', 1, length(param1));
+    end
     for iAlpha = 1:length(alpha)
         
         inv_matrix = inv( GSG  + alpha(iAlpha) * Sigma_d );
@@ -87,8 +88,9 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
 
         Fit(iAlpha)     = normest(residual_kernal*M);  % Define Fit as a function of alpha
         Prior(iAlpha)   = normest(wKernel*M);      % Define Prior as a function of alpha
-    
-        bst_progress('inc', 1); 
+        if ~OPTIONS.automatic.stand_alone
+            bst_progress('inc', 1); 
+        end
     end
 
     % Fid alpha optimal based on l-curve
@@ -101,6 +103,9 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
         varargout{1} = alpha(Index);
     end
 
+    if ~OPTIONS.automatic.stand_alone
+        bst_progress('stop');
+    end
     fprintf('done. \n');
     
     if OPTIONS.optional.display


### PR DESCRIPTION
Improve the variable slicing for the par-for loop, reducing the data transfer to the workers. 

OLD: 

             BytesSentToWorkers    BytesReceivedFromWorkers
             __________________    ________________________

    1            6.8477e+07               5.1198e+06       
    2            6.8475e+07               4.8475e+06       
    3             6.848e+07               5.1902e+06       
    4            6.8475e+07               4.8485e+06       
    5             6.848e+07               5.3961e+06       
    6             6.848e+07               5.3966e+06       
    Total        4.1087e+08               3.0799e+07   


NEW : 
             BytesSentToWorkers    BytesReceivedFromWorkers
             __________________    ________________________

    1            2.4807e+07               4.8351e+06       
    2            2.5551e+07               5.1078e+06       
    3            2.4807e+07               4.8337e+06       
    4            2.5551e+07               5.1071e+06       
    5             2.574e+07               5.1768e+06       
    6            2.7041e+07               5.6541e+06       
    Total         1.535e+08               3.0715e+07     

This represents a 62% reduction in data transfer. (might be even better for longer data, more worker)

Information about slice variable here: https://www.mathworks.com/help/parallel-computing/sliced-variable.html
