### PR TITLE
MNE kernel

### DIFF
--- a/best/misc/mne/be_jmne_lcurve.m
+++ b/best/misc/mne/be_jmne_lcurve.m
@@ -67,17 +67,17 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
     wSG = sqrt(Sigma_s) * G';
 
     % Parameter for l-curve
-    param1  = [0.1:0.1:1 1:5:100 100:100:1000]; 
+    param  = logspace(-2,3,100);
 
     % Scale alpha using trace(G*G')./trace(W'*W)  
     scale   = trace(G*G')./ trace(inv(Sigma_s));       
-    alpha   = param1.*scale;
+    alpha   = param.*scale;
 
 
     Fit     = zeros(1,length(alpha));
     Prior   = zeros(1,length(alpha));
     if ~OPTIONS.automatic.stand_alone
-        bst_progress('start', 'wMNE, solving MNE by L-curve ... ' , 'Solving MNE by L-curve ... ', 1, length(param1));
+        bst_progress('start', 'wMNE, solving MNE by L-curve ... ' , 'Solving MNE by L-curve ... ', 1, length(alpha));
     end
     for iAlpha = 1:length(alpha)
         

--- a/best/misc/mne/be_jmne_lcurve.m
+++ b/best/misc/mne/be_jmne_lcurve.m
@@ -73,6 +73,8 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
     scale   = trace(G*G')./ trace(inv(Sigma_s));       
     alpha   = param.*scale;
 
+    % Pre-compute data decomposition
+    [U,S]   = svd(M,'econ'); 
 
     Fit     = zeros(1,length(alpha));
     Prior   = zeros(1,length(alpha));
@@ -83,11 +85,17 @@ function [J,varargout] = be_jmne_lcurve(G,M,OPTIONS, sfig)
         
         inv_matrix = inv( GSG  + alpha(iAlpha) * Sigma_d );
         
+        % Define both Kernel
         residual_kernal = eye(size(M,1)) - GSG * inv_matrix;
-        wKernel = wSG*inv_matrix;
+        wKernel         = wSG*inv_matrix;
+        
+        % Estimate the corresponding norm
+        R = qr(residual_kernal*U);
+        Fit(iAlpha)     = norm(R*S);
 
-        Fit(iAlpha)     = normest(residual_kernal*M);  % Define Fit as a function of alpha
-        Prior(iAlpha)   = normest(wKernel*M);      % Define Prior as a function of alpha
+        R = qr(wKernel*U);
+        Prior(iAlpha)   = norm(R*S);
+        
         if ~OPTIONS.automatic.stand_alone
             bst_progress('inc', 1); 
         end


### PR DESCRIPTION
Improve the estimation of MNE kernel to have the estimation done in O(1)  (independent of data length)

this is based on the fact that norm(B*A) can be calculated without explicitly calculating B*A. Here A is the data, and B is the kernel matrix.

